### PR TITLE
Added Display and Overhauled Error Handling

### DIFF
--- a/src/alu.rs
+++ b/src/alu.rs
@@ -43,12 +43,12 @@ impl ArithmeticLogicUnit
 
     fn add()
     {
-
+        // BIG NOTE: NEED TO ALLOW OVERFLOW HERE! VARIABLES WILL NOT DO IT NATURALLY
     }
 
     fn sub()
     {
-
+        // BIG NOTE: NEED TO ALLOW OVERFLOW HERE! VARIABLES WILL NOT DO IT NATURALLY
     }
 
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -29,8 +29,17 @@ impl Console
 		}
 	}
 
-	pub fn handle_in(&mut self, raw_line:  &str)
-	{
+	pub fn handle_in(&mut self, raw_line:  &str) -> u8 // returns 0 for success and positives for error and type
+	{   
+		/*
+			Error Codes:
+			0 => Success
+			1 => Not Implemented Operation
+			2 => Null Command
+			3 => dr, s1, or s2 not found
+			4 => dr, s1, or s2 were nonnumeric address
+		*/
+
 		let mut command = raw_line.split_whitespace();
 		let mut skip = false;
 
@@ -38,17 +47,15 @@ impl Console
 		match command.next()
 		{
 			// exit command
-			Some("BREAK") => { println!("Break command entered..."); self.op = AsbType::BRK; skip = true; }
+			Some("BREAK") => { self.op = AsbType::BRK; skip = true; }
 
 			// Main Assembly Code
-			Some("NOT") => { println!("Not command"); self.op = AsbType::NOT; }
+			Some("NOT") => { self.op = AsbType::NOT; }
 
-			Some(_) => { println!("not implemented..."); self.op = AsbType::INV; skip = true; }
+			Some(_) => { self.op = AsbType::INV; skip = true; return 1; }
 
-			None => { println!("Command Not Entered..."); self.op = AsbType::INV; skip = true; }
+			None => { self.op = AsbType::INV; return 2; }
 		}
-
-		if skip { return; }
 
 
 		// Assigning registers
@@ -58,13 +65,13 @@ impl Console
 		let first_arg = match first_arg 
 		{
 			Some(arg) => arg,
-			None => { self.op = AsbType::INV; println!(".\nStd in not found\n."); return; }
+			None => { self.op = AsbType::INV; return 3; }
 		};
 		let first_arg = first_arg.parse::<i32>();
 		let first_arg = match first_arg
 		{
 			Ok(arg) => arg,
-			Err(_e) => { self.op = AsbType::INV; println!(".\ndrive must be mem address (non-number error)\n."); return; }
+			Err(_e) => { self.op = AsbType::INV; return 4; }
 		};
 		self.dr = first_arg as u8;
 
@@ -73,13 +80,13 @@ impl Console
 		let second_arg = match second_arg
 		{
 			Some(arg) => arg,
-			None => { self.op = AsbType::INV; println!(".\nStd in not found\n."); return; }
+			None => { self.op = AsbType::INV; return 3; }
 		};
 		let second_arg = second_arg.parse::<i32>();
 		let second_arg = match second_arg
 		{
 			Ok(arg) => arg,
-			Err(_e) => { self.op = AsbType::INV; println!(".\ns1 must be mem address (non-number error)\n."); return; }
+			Err(_e) => { self.op = AsbType::INV; return 4; }
 		};
 		self.s1 = second_arg as u8;
 
@@ -88,16 +95,17 @@ impl Console
 		let third_arg = match third_arg
 		{
 			Some(arg) => arg,
-			None => { self.op = AsbType::INV; println!(".\nStd in not found\n."); return; }
+			None => { self.op = AsbType::INV; return 3; }
 		};
 		let third_arg = third_arg.parse::<i32>();
 		let third_arg = match third_arg
 		{
 			Ok(arg) => arg,
-			Err(_e) => { self.op = AsbType::INV; println!(".\ns2 must be mem address (non-number error)\n."); return; }
+			Err(_e) => { self.op = AsbType::INV; return 4; }
 		};
 		self.s2 = third_arg as u8;
 
+		0 // success returned
 	}
 
 	

--- a/src/console.rs
+++ b/src/console.rs
@@ -38,6 +38,7 @@ impl Console
 			2 => Null Command
 			3 => dr, s1, or s2 not found
 			4 => dr, s1, or s2 were nonnumeric address
+			5 => default display value and used for break
 		*/
 
 		let mut command = raw_line.split_whitespace();
@@ -47,7 +48,7 @@ impl Console
 		match command.next()
 		{
 			// exit command
-			Some("BREAK") => { self.op = AsbType::BRK; skip = true; }
+			Some("BREAK") => { self.op = AsbType::BRK; return 5;  }
 
 			// Main Assembly Code
 			Some("NOT") => { self.op = AsbType::NOT; }

--- a/src/display.rs
+++ b/src/display.rs
@@ -8,9 +8,20 @@ pub fn clear_screen()
     
 }
 
-pub fn window(last_command: &str, mioi: &super::memory_io_interface::MemIOInterface)
+pub fn window(last_command: &str, mioi: &super::memory_io_interface::MemIOInterface, error: u8)
 {   
-    println!("\n\n\n\n\n\n");
+    let error_line = match error
+    {
+        0 => "Success                              ",
+        1 => "!!! Entered a Non-Implemented Command",
+        2 => "!!! Null Command (No Command Found)  ",
+        3 => "!!! Register or Arguments Not Found  ",
+        4 => "!!! DR or Arguments Were Not Numeric ",
+        _ => "                                     ",
+    };
+
+
+    println!("\n\n\n\n\n");
     println!("################################################################################");
     println!("################################################################################");
     println!("# Virtual Assebmly Computer - v0.1                                             #");
@@ -24,6 +35,7 @@ pub fn window(last_command: &str, mioi: &super::memory_io_interface::MemIOInterf
     println!("#  Registers above, Assembly Commands in Manual (will be impl on command)      #");
     println!("#                                                                              #");
     println!("#==> Last Command: {}                                    ", last_command);
+    println!("#==> Result: {}                           #", error_line);
     println!("#                                                                              #");
     println!("#  Current Instruction Address: {}                #", "(Not Implemented, No File Read)");
     println!("#  Type Assembly Command Below...                                              #");

--- a/src/display.rs
+++ b/src/display.rs
@@ -9,10 +9,24 @@ pub fn clear_screen()
     
 }
 
-pub fn window()
+pub fn window(last_command: &str, reg: &super::memory_io_interface::MemIOInterface)
 {
     println!("################################################################################");
-    println!("# This is a test                                                               #");
-    println!("R1:{0:b}  R2: {1:b}  R3:{2:b}   #", 8, 10, 255);
+    println!("################################################################################");
+    println!("# Virtual Assebmly Computer - v0.1                                             #");
+    println!("#                                                                              #");
+    println!("#==============================================================================#");
+    println!("# R1:{0:#10b} ||  R2: {1:#10b} || R3:{2:#10b}    ||                      #", mioi.mem[0].val, 10, 255);
+    println!("# R4:{0:#10b} ||  R5: {1:#10b} ||  R6:{2:#10b}    ||                     #", 0, 2, 7);
+    println!("# R7:{0:#10b} ||  R8: {1:#10b} ||  R9:{2:#10b}   ||                      #", 1, 2, 203);
+    println!("# R10:{0:#10b} ||                                                             #", 80);
+    println!("#==============================================================================#");
+    println!("#  Registers above, Assembly Commands in Manual (will be impl on command)      #");
+    println!("#                                                                              #");
+    println!("#  Last Command: {}                                      ", last_command);
+    println!("#                                                                              #");
+    println!("#  Current Instruction Address: {}                #", "(Not Implemented, No File Read)");
+    println!("#  Type Assembly Command Below...                                              #");
+    println!("################################################################################");
     println!("################################################################################");
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+
+
+pub fn clear_screen()
+{
+    println!("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+    println!(".\nBeginning VAC\n.\n.");
+    
+}
+
+pub fn window()
+{
+    println!("################################################################################");
+    println!("# This is a test                                                               #");
+    println!("R1:{0:b}  R2: {1:b}  R3:{2:b}   #", 8, 10, 255);
+    println!("################################################################################");
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,29 +1,29 @@
-use std::process::Command;
-
+// use std::process::Command;
 
 
 pub fn clear_screen()
 {
     println!("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-    println!(".\nBeginning VAC\n.\n.");
+    println!(".\nBeginning VAC in Terminal\n.\n.");
     
 }
 
-pub fn window(last_command: &str, reg: &super::memory_io_interface::MemIOInterface)
-{
+pub fn window(last_command: &str, mioi: &super::memory_io_interface::MemIOInterface)
+{   
+    println!("\n\n\n\n\n\n");
     println!("################################################################################");
     println!("################################################################################");
     println!("# Virtual Assebmly Computer - v0.1                                             #");
     println!("#                                                                              #");
     println!("#==============================================================================#");
-    println!("# R1:{0:#10b} ||  R2: {1:#10b} || R3:{2:#10b}    ||                      #", mioi.mem[0].val, 10, 255);
-    println!("# R4:{0:#10b} ||  R5: {1:#10b} ||  R6:{2:#10b}    ||                     #", 0, 2, 7);
-    println!("# R7:{0:#10b} ||  R8: {1:#10b} ||  R9:{2:#10b}   ||                      #", 1, 2, 203);
-    println!("# R10:{0:#10b} ||                                                             #", 80);
+    println!("# R0:{0:10b} ||  R1: {1:10b} || R2:{2:10b}    ||                      #", mioi.give_registers(0), mioi.give_registers(1), mioi.give_registers(2));
+    println!("# R3:{0:10b} ||  R4: {1:10b} ||  R5:{2:10b}   ||                     #", mioi.give_registers(3), mioi.give_registers(4), mioi.give_registers(5));
+    println!("# R6:{0:10b} ||  R7: {1:10b} ||  R8:{2:10b}   ||                      #", mioi.give_registers(6), mioi.give_registers(7), mioi.give_registers(8));
+    println!("# R9:{0:10b} ||                                                             #", mioi.give_registers(9));
     println!("#==============================================================================#");
     println!("#  Registers above, Assembly Commands in Manual (will be impl on command)      #");
     println!("#                                                                              #");
-    println!("#  Last Command: {}                                      ", last_command);
+    println!("#==> Last Command: {}                                    ", last_command);
     println!("#                                                                              #");
     println!("#  Current Instruction Address: {}                #", "(Not Implemented, No File Read)");
     println!("#  Type Assembly Command Below...                                              #");

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,12 +25,14 @@ fn main() {
 
 		con.handle_in(&asb_line);
 		if con.op == console::AsbType::BRK { break; }
-		if con.op == console::AsbType::INV { continue; }
+		if con.op == console::AsbType::INV {  }
+		else
+		{
+			alu::ArithmeticLogicUnit::execute(&mut mioi, &con);
+		}
 
-		alu::ArithmeticLogicUnit::execute(&mut mioi, &con);
-
-		// FOR DEBUG ONLY CURRENTLY:
-		mioi.to_screen();
+		// display
+		display::window(&asb_line, &mioi);
 	}
 
 	// mioi.shut_down();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,10 @@ fn main() {
 	// Note: Set amount of registers inside mem_io
 
 	// Computer Run
+	display::clear_screen();
+	display::window("NONE", &mioi);
 	loop 
 	{
-		display::clear_screen();
-		display::window();
-
 		let mut asb_line = String::new();
 		asb_line.clear();
 		io::stdin().read_line(&mut asb_line).expect("Invalid Read of Standard In!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,27 +15,25 @@ fn main() {
 
 	// Computer Run
 	display::clear_screen();
-	display::window("NONE", &mioi);
+	display::window("NONE", &mioi, 5); // default values for display (specifically, 5 displays no result of last command)
 	loop 
 	{
 		let mut asb_line = String::new();
 		asb_line.clear();
-		io::stdin().read_line(&mut asb_line).expect("Invalid Read of Standard In!");
+		io::stdin().read_line(&mut asb_line).expect("Invalid Read of Standard In!"); // Reads command
 
-
-		con.handle_in(&asb_line);
-		if con.op == console::AsbType::BRK { break; }
-		if con.op == console::AsbType::INV {  }
-		else
-		{
-			alu::ArithmeticLogicUnit::execute(&mut mioi, &con);
-		}
+		// con: Console handles the command and seperates it into dr s1 and s2 (as its own fields)
+		let e_result = con.handle_in(&asb_line);
+		if con.op == console::AsbType::BRK { break; } 
+		if con.op == console::AsbType::INV { asb_line.pop(); display::window(&asb_line, &mioi, e_result); continue;  }
+		
+		alu::ArithmeticLogicUnit::execute(&mut mioi, &con); // handles register bitwise operations
 
 		// display
-		display::window(&asb_line, &mioi);
+		asb_line.pop();
+		display::window(&asb_line, &mioi, e_result); // displays registers and command
 	}
 
-	// mioi.shut_down();
 
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod memory_io_interface;
 mod console;
 mod alu;
+mod display;
 use std::io;
 
 fn main() {
@@ -15,6 +16,9 @@ fn main() {
 	// Computer Run
 	loop 
 	{
+		display::clear_screen();
+		display::window();
+
 		let mut asb_line = String::new();
 		asb_line.clear();
 		io::stdin().read_line(&mut asb_line).expect("Invalid Read of Standard In!");
@@ -39,4 +43,3 @@ fn boot_up() -> console::Console
 {
 	console::Console::new("no file")
 }
-

--- a/src/memory_io_interface.rs
+++ b/src/memory_io_interface.rs
@@ -36,9 +36,9 @@ impl MemIOInterface
     // }
 
 
-    pub fn give_registers(&self, i: u8) -> u8
+    pub fn give_registers(&self, i: usize) -> u8
     {
-        self.mem[]
+        self.mem[i].val
     }
 
 

--- a/src/memory_io_interface.rs
+++ b/src/memory_io_interface.rs
@@ -3,7 +3,7 @@ mod register;
 pub struct MemIOInterface
 {
     mem: [register::Register; 10], // change memory means change this array as well as below size
-    _size: i32,
+    size: i32,
 }
 
 impl MemIOInterface
@@ -14,7 +14,7 @@ impl MemIOInterface
         MemIOInterface
         {
             mem: [register::Register::new(); CHANGE_MEM_HERE as usize],
-            _size: CHANGE_MEM_HERE,
+            size: CHANGE_MEM_HERE,
         }
     }
 
@@ -36,19 +36,11 @@ impl MemIOInterface
     // }
 
 
-    // FOR DEBUG ONLY
-    pub fn to_screen(&self)
+    pub fn give_registers(&self, i: u8) -> u8
     {
-        println!("Register 0 has: {} ", self.mem[0].val);
-        println!("Register 1 has: {} ", self.mem[1].val);
-        println!("Register 2 has: {} ", self.mem[2].val);
-        println!("Register 3 has: {} ", self.mem[3].val);
-        println!("Register 4 has: {} ", self.mem[4].val);
-        println!("Register 5 has: {} ", self.mem[5].val);
-        println!("Register 6 has: {} ", self.mem[6].val);
-        println!("Register 7 has: {} ", self.mem[7].val);
-        println!("Register 8 has: {} ", self.mem[8].val);
-        println!("Register 9 has: {} ", self.mem[9].val);
+        self.mem[]
     }
+
+
 
 }


### PR DESCRIPTION
Changes to 0.1:

- Display implemented, now see register contents and have nice visual display for inputting assembly commands.
- Errors in assembly commands no longer panic!() now errors are exceptions.
- Errors display changed.  Command now returns numbers used for matching that allows display to include info on failure on screen.